### PR TITLE
Add an else clause to not break in Firefox 49+

### DIFF
--- a/js/parallax.js
+++ b/js/parallax.js
@@ -409,7 +409,7 @@ $(function(){
 				if( null != props.left ){ props.left = 0; }
 			}
 
-			if( mozCSS || msCSS ){
+			else if( mozCSS || msCSS ){
 				props[ mozCSS ? 'MozTransform' : 'msTransform' ] = ( props.top ? 'translateY(' + props.top + 'px)' : '' ) + ( props.left ? 'translateX(' + props.left + 'px)' : '' );
 				
 				if( null != props.top  ){ props.top  = 0; }


### PR DESCRIPTION
It has support for -webkit- prefixed aliases, in addition to -moz- prefixed CSS. 
Realistically, in 2016 this would have an unprefixed version as well.

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1305467