### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,6 @@ Add properties to your elements, e.g. `<section anim-pause="200">`
 
 include `side-nav.js` to add an auto-generated side navigation bar.  This bar is generated from all `section h2:first` elements.
 
-##Features
+## Features
 
 All animations are done using CSS3 transformations whenever possible and fall back to normal CSS positioning when necessary.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
